### PR TITLE
Remove convoluted bootstrap row code

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ layout: default
     <ul class="category-list">
      <div class="row">
       {% for post in site.categories.recipes limit: 3 %}
-      
+
         <div class="col-sm-4">
           <a class="activeimage" href="{{ post.url }}">
           {% if post.primaryimage %}
@@ -16,14 +16,14 @@ layout: default
           {% endif %}
 
           <h5 class="category-recipe-title">{{ post.title }}</h5></a>
-          
+
         </div>
-     
+
       {% endfor %}
        </div>
     </ul>
 
-  
+
     <div class="row welcome-mat">
       <div class="col-sm-8"><h1>Welcome!</h1>Hello, I'm Lauren, and welcome to Effin' Tasty, a cooking site dedicated to sharing my love for effin' tasty foods and the knowledge I've collected along the way creating them. And more copy and more copy and more.</div>
       <div class="col-sm-4"><img class= "img-responsive img-circle about" src="/assets/About_pic.jpg"></div>

--- a/index.html
+++ b/index.html
@@ -31,36 +31,19 @@ layout: default
 
   <h1 class="welcome-mat-room">Tasty Types</h1>
     <ul class="category-list">
-      <!-- build category_names array -->
-      {% assign category_names = "" | split:"|" %}
-      {% for category in site.categories %}
+      <div class="row">
+      <!-- Sort categories -->
+      {% assign sorted_categories = site.categories | sort %}
+      {% for category in sorted_categories %}
+      <!-- Grab the category name ( which is the first string in the array, it's [categoryName, [categoryposts...]]) -->
       {% assign category_name = (category | first) %}
+      <!-- Skip the "recipes" category -->
       {% if category_name == "recipes" %}
       {% continue %}
       {% endif %}
-      {% assign category_names=category_names | push: category_name %}
+      <!-- category_links expects an array, so we put our single category into an array -->
+      {% assign category_name_array = category_name | split: "|" %}
+      <div class="col-sm-3">{{ category_name_array] | category_links }}</div>
       {% endfor %}
-
-      <!-- Sort category_names -->
-      {% assign category_names=category_names | sort %}
-
-      <!-- Build category grid -->
-      {% for category in category_names %}
-      {% assign category_array = category | split:"|" %}
-
-      {% capture modulo %}{{ forloop.index0 | mod:4 }}{% endcapture %}
-
-      <!-- Modulo to begin bootstrap row -->
-      {% if modulo == '0' or forloop.first %}
-      <div class="row">
-      {% endif %}
-
-        <div class="col-sm-3">{{ category_array | category_links }}</div>
-
-      <!-- Modulo to end bootstrap row -->
-      {% if modulo == '3' or forloop.last %}
-      </div>
-      {% endif %}
-
-      {% endfor %}
+    </div>
     </ul>

--- a/index.html
+++ b/index.html
@@ -1,49 +1,49 @@
 ---
 layout: default
 ---
-  <h1>New & Tasty</h1>
+<h1>New & Tasty</h1>
 
-    <ul class="category-list">
-     <div class="row">
-      {% for post in site.categories.recipes limit: 3 %}
+  <ul class="category-list">
+   <div class="row">
+    {% for post in site.categories.recipes limit: 3 %}
 
-        <div class="col-sm-4">
-          <a class="activeimage" href="{{ post.url }}">
-          {% if post.primaryimage %}
+      <div class="col-sm-4">
+        <a class="activeimage" href="{{ post.url }}">
+        {% if post.primaryimage %}
 
-          <img class="img-responsive img-rounded" src="{{ site.baseurl }}/assets/{{post.primaryimage}}">
+        <img class="img-responsive img-rounded" src="{{ site.baseurl }}/assets/{{post.primaryimage}}">
 
-          {% endif %}
+        {% endif %}
 
-          <h5 class="category-recipe-title">{{ post.title }}</h5></a>
+        <h5 class="category-recipe-title">{{ post.title }}</h5></a>
 
-        </div>
+      </div>
 
-      {% endfor %}
-       </div>
-    </ul>
+    {% endfor %}
+     </div>
+  </ul>
 
 
-    <div class="row welcome-mat">
-      <div class="col-sm-8"><h1>Welcome!</h1>Hello, I'm Lauren, and welcome to Effin' Tasty, a cooking site dedicated to sharing my love for effin' tasty foods and the knowledge I've collected along the way creating them. And more copy and more copy and more.</div>
-      <div class="col-sm-4"><img class= "img-responsive img-circle about" src="/assets/About_pic.jpg"></div>
-    </div>
+  <div class="row welcome-mat">
+    <div class="col-sm-8"><h1>Welcome!</h1>Hello, I'm Lauren, and welcome to Effin' Tasty, a cooking site dedicated to sharing my love for effin' tasty foods and the knowledge I've collected along the way creating them. And more copy and more copy and more.</div>
+    <div class="col-sm-4"><img class= "img-responsive img-circle about" src="/assets/About_pic.jpg"></div>
+  </div>
 
-  <h1 class="welcome-mat-room">Tasty Types</h1>
-    <ul class="category-list">
-      <div class="row">
-      <!-- Sort categories -->
-      {% assign sorted_categories = site.categories | sort %}
-      {% for category in sorted_categories %}
-      <!-- Grab the category name ( which is the first string in the array, it's [categoryName, [categoryposts...]]) -->
-      {% assign category_name = (category | first) %}
-      <!-- Skip the "recipes" category -->
-      {% if category_name == "recipes" %}
-      {% continue %}
-      {% endif %}
-      <!-- category_links expects an array, so we put our single category into an array -->
-      {% assign category_name_array = category_name | split: "|" %}
-      <div class="col-sm-3">{{ category_name_array] | category_links }}</div>
-      {% endfor %}
-    </div>
-    </ul>
+<h1 class="welcome-mat-room">Tasty Types</h1>
+  <ul class="category-list">
+    <div class="row">
+    <!-- Sort categories -->
+    {% assign sorted_categories = site.categories | sort %}
+    {% for category in sorted_categories %}
+    <!-- Grab the category name ( which is the first string in the array, it's [categoryName, [categoryposts...]]) -->
+    {% assign category_name = (category | first) %}
+    <!-- Skip the "recipes" category -->
+    {% if category_name == "recipes" %}
+    {% continue %}
+    {% endif %}
+    <!-- category_links expects an array, so we put our single category into an array -->
+    {% assign category_name_array = category_name | split: "|" %}
+    <div class="col-sm-3">{{ category_name_array] | category_links }}</div>
+    {% endfor %}
+  </div>
+  </ul>


### PR DESCRIPTION
Removed the code in `index.html` that was used to create new rows for bootstrap. Bootstrap will do this automatically.

> If more than 12 columns are placed within a single row, each group of extra columns will, as one unit, wrap onto a new line.
[http://getbootstrap.com/css/](http://getbootstrap.com/css/)